### PR TITLE
Use published os_stat.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -473,7 +473,7 @@ dependencies = [
  "hostname",
  "lazy_static",
  "mackerel_client",
- "os-stat-rs",
+ "os_stat",
  "regex",
  "serde",
  "serde_json",
@@ -681,9 +681,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "os-stat-rs"
+name = "os_stat"
 version = "0.1.0"
-source = "git+https://github.com/Krout0n/os-stat-rs#8cbf5f27001e6c3988754d2b680ee3484a62181c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1526f86dbc01a8a1bf56ba3a15caa070b824d19447418777e422e18930feb2"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ compile-time-run = "0.2.11"
 hostname = "^0.3"
 lazy_static = "1.4.0"
 mackerel_client = { git = "https://github.com/Krout0n/mackerel-client-rs" }
-os-stat-rs = { git = "https://github.com/Krout0n/os-stat-rs" }
+os_stat = "0.1.0"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.56"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,10 +1,10 @@
 use crate::{Agent, Values};
-use os_stat_rs::cpu;
+use os_stat::CPU;
 use std::{collections::HashMap, time::Duration};
 
-impl From<(cpu::CPU, cpu::CPU)> for Values {
+impl From<(CPU, CPU)> for Values {
     // https://github.com/mackerelio/mackerel-agent/blob/d9e3082a32b96c17560a375e5e78babcb0f34e8d/metrics/linux/cpuusage.go#L31-L75
-    fn from((previous, current): (cpu::CPU, cpu::CPU)) -> Self {
+    fn from((previous, current): (CPU, CPU)) -> Self {
         let mut value = HashMap::new();
         let total_diff = (current.total - previous.total) as f64;
         let cpu_count = current.cpu_count as f64;
@@ -54,9 +54,9 @@ impl From<(cpu::CPU, cpu::CPU)> for Values {
 impl Agent {
     pub fn get_cpu_metrics() -> Option<Values> {
         let interval = Duration::from_secs(10);
-        let previous = cpu::get();
+        let previous = CPU::get();
         std::thread::sleep(interval);
-        let current = cpu::get();
+        let current = CPU::get();
         match (previous, current) {
             (Ok(previous), Ok(current)) => Some((previous, current).into()),
             _ => None,

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -1,13 +1,13 @@
 use crate::{util, Agent, Values};
-use os_stat_rs::disk;
+use os_stat::Disk;
 use std::{collections::HashMap, time::Duration};
 
 impl Agent {
     pub fn get_disk_metrics() -> Option<Values> {
         let interval = Duration::from_secs(10);
-        let previous = disk::get().expect("failed to get disk statistics");
+        let previous = Disk::get().expect("failed to get disk statistics");
         std::thread::sleep(interval);
-        let current = disk::get().expect("failed to get disk statistics");
+        let current = Disk::get().expect("failed to get disk statistics");
         let mut previous_values = HashMap::new();
         for v in &previous {
             previous_values.insert(v.name.clone(), v);

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,10 +1,10 @@
 use crate::{Agent, Values};
-use os_stat_rs::filesystem;
+use os_stat::FileSystem;
 use std::collections::HashMap;
 
 impl Agent {
     pub fn get_filesystem_metrics() -> Values {
-        let stats = filesystem::get().expect("failed to get filesystem metrics");
+        let stats = FileSystem::get().expect("failed to get filesystem metrics");
         let mut values = HashMap::new();
         for stats_item in stats {
             values.insert(

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,5 +1,5 @@
 use crate::{Agent, Values};
-use os_stat_rs::network;
+use os_stat::Network;
 use std::collections::HashMap;
 
 const INTERNAL_SECONDS: u64 = 10;
@@ -22,7 +22,7 @@ impl From<(HashMap<String, f64>, HashMap<String, f64>)> for Values {
     }
 }
 
-fn network_to_hashmap(nw_stats: Vec<network::Network>) -> HashMap<String, f64> {
+fn network_to_hashmap(nw_stats: Vec<Network>) -> HashMap<String, f64> {
     let mut value = HashMap::new();
     for network in nw_stats.into_iter() {
         let name = crate::util::sanitize_metric_key(&network.name);
@@ -41,9 +41,9 @@ fn network_to_hashmap(nw_stats: Vec<network::Network>) -> HashMap<String, f64> {
 impl Agent {
     pub fn get_interfaces_metrics() -> Option<Values> {
         let interval = std::time::Duration::from_secs(INTERNAL_SECONDS);
-        let previous = network::get();
+        let previous = Network::get();
         std::thread::sleep(interval);
-        let current = network::get();
+        let current = Network::get();
         match (previous, current) {
             (Ok(previous), Ok(current)) => {
                 let previous_metrics = network_to_hashmap(previous);

--- a/src/loadavg.rs
+++ b/src/loadavg.rs
@@ -1,10 +1,10 @@
 use crate::{Agent, Values};
-use os_stat_rs::loadavg;
+use os_stat::LoadAvg;
 use std::collections::HashMap;
 
 impl Agent {
     pub fn get_loadavg_metric() -> Values {
-        let loadavg_stats = loadavg::get();
+        let loadavg_stats = LoadAvg::get();
         let mut values = HashMap::new();
         values.insert("loadavg1".into(), loadavg_stats.loadavg1);
         values.insert("loadavg5".into(), loadavg_stats.loadavg5);

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,10 +1,10 @@
 use crate::{Agent, Values};
-use os_stat_rs::memory;
+use os_stat::Memory;
 use std::collections::HashMap;
 
 impl Agent {
     pub fn get_memory_metrics() -> Values {
-        let mem = memory::get().expect("failed to get memory statistics");
+        let mem = Memory::get().expect("failed to get memory statistics");
         let mut values = HashMap::new();
         values.insert("memory.total".into(), mem.total as f64);
         values.insert("memory.used".into(), mem.used as f64);


### PR DESCRIPTION
Just now, `os_stat` [updates new version](https://crates.io/crates/os_stat). So, we must use it.