### PR TITLE
Add one simple custom metric.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "mackerel_client"
 version = "0.4.0"
-source = "git+https://github.com/Krout0n/mackerel-client-rs#f2f87cb4cf3c1d30c75725e2db37e618b7f1a902"
+source = "git+https://github.com/Krout0n/mackerel-client-rs#e49fc4fb535363db30aa876ccbe030ad7b59a8b0"
 dependencies = [
  "error-chain",
  "reqwest",

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ pub struct Config {
     pub apikey: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom: Option<String>,
 }
 
 impl Config {
@@ -16,6 +18,7 @@ impl Config {
             apibase: String::new(),
             apikey: String::new(),
             roles: Some(vec![]),
+            custom: None,
         }
     }
 
@@ -38,11 +41,13 @@ fn test_from_toml() {
 apibase = "https://example.com"
 apikey = "example_apikey"
 roles = ["example_service: example_role"]
+custom = "ls -l"
 "#;
     let expected = Config {
         apibase: "https://example.com".to_owned(),
         apikey: "example_apikey".to_owned(),
         roles: Some(vec!["example_service: example_role".to_owned()]),
+        custom: Some("ls -l".into()),
     };
     assert_eq!(Config::from_toml(toml), expected);
 }
@@ -52,11 +57,13 @@ fn test_from_toml_without_apibase() {
     let toml = r#"
 apikey = "example_apikey"
 roles = ["example_service: example_role"]
+custom = "ls -l"
 "#;
     let expected = Config {
         apikey: "example_apikey".to_owned(),
         apibase: "https://api.mackerelio.com/".to_owned(),
         roles: Some(vec!["example_service: example_role".to_owned()]),
+        custom: Some("ls -l".into()),
     };
     assert_eq!(Config::from_toml(toml), expected);
 }
@@ -66,11 +73,29 @@ fn test_from_toml_without_roles() {
     let toml = r#"
 apikey = "example_apikey"
 apibase = "https://example.com"
+custom = "ls -l"
 "#;
     let expected = Config {
         apibase: "https://example.com".to_owned(),
         apikey: "example_apikey".to_owned(),
         roles: None,
+        custom: Some("ls -l".into()),
+    };
+    assert_eq!(Config::from_toml(toml), expected);
+}
+
+#[test]
+fn test_from_toml_without_custom() {
+    let toml = r#"
+apikey = "example_apikey"
+apibase = "https://example.com"
+roles = ["example_service: example_role"]
+"#;
+    let expected = Config {
+        apibase: "https://example.com".to_owned(),
+        apikey: "example_apikey".to_owned(),
+        roles: Some(vec!["example_service: example_role".to_owned()]),
+        custom: None,
     };
     assert_eq!(Config::from_toml(toml), expected);
 }

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -15,6 +15,7 @@ pub enum HostMetricKind {
     Custom(String),
 }
 
+#[derive(Debug, PartialEq)]
 pub struct HostMetric {
     pub kind: HostMetricKind,
     pub value: MetricValue,


### PR DESCRIPTION
Now, our config parser accepts like `custom = "/bin/echo 10"` and accumulate it as custom-metric.
It's hard to implement a feature that meets custom metric specifications in one fell swoop, so I submitted a simple PR once.