### PR TITLE
Fix: rustfmt isn't in the current nightly toolchain.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 
 .PHONY: test
 test: ## Test.
-	cargo fmt --all -- --check
+	cargo +nightly-2020-10-08 fmt --all -- --check
 	cargo clippy -- -D warnings
 	cargo test --no-fail-fast -- --nocapture
 ifeq ($(within_docker),)

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 
 .PHONY: test
 test: ## Test.
-	cargo +nightly-2020-10-08 fmt --all -- --check
+	cargo fmt --all -- --check
 	cargo clippy -- -D warnings
 	cargo test --no-fail-fast -- --nocapture
 ifeq ($(within_docker),)

--- a/deployments/development/Dockerfile
+++ b/deployments/development/Dockerfile
@@ -15,9 +15,10 @@ RUN apt-get -y update \
     rsync \
  && rustup default nightly \
  && cargo install cargo-watch \
+ && rustup toolchain add nightly-2020-10-08 \
  && rustup component add clippy \
  && rustup component add rust-src \
- && rustup component add rustfmt \
+ && rustup component add --toolchain nightly-2020-10-08 rustfmt \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/deployments/development/Dockerfile
+++ b/deployments/development/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get -y update \
     rsync \
  && rustup default nightly \
  && cargo install cargo-watch \
- && rustup toolchain add nightly-2020-10-08 \
- && rustup component add clippy \
- && rustup component add rust-src \
- && rustup component add --toolchain nightly-2020-10-08 rustfmt \
+ && rustup toolchain install nightly --allow-downgrade -c \
+    clippy \
+    rust-src \
+    rustfmt \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Like this issue: https://github.com/rust-lang/rustfmt/issues/3404 .
`make sh` crushes the same error.

I choosed the last stable release date. https://github.com/rust-lang/rust/blob/master/RELEASES.md

After this pull request `make sh` and `make test` should works.